### PR TITLE
remove unnecessary p tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,6 @@
             <button id="close-dialog">Thanks</button>
         </dialog>
 
-        <p><abbr title="Hypertext Markup Language">HTML</abbr> is a markup language used for creating web pages.</p>
     </section>
 </body>
 </html>


### PR DESCRIPTION
I remove unnecessary P tag. The tag is a typo because it talks about HTML instead of you.